### PR TITLE
Add scripts for serving and deploying backups

### DIFF
--- a/user_account/scripts/backup_deploy.sh
+++ b/user_account/scripts/backup_deploy.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+main() {
+	local -r server_ip="${1}"
+	local -r official_tar="official.tar"
+	local -r database_kdbx="Database.kdbx"
+	local -r database_bak="Database.bak"
+
+	if [ -z "${server_ip}" ] ; then
+		echo "Server IP not provided as first argument. Exiting."
+		exit 1
+	fi
+
+	pushd /tmp
+
+	wget ${server_ip}:8000/${database_kdbx}
+	wget ${server_ip}:8000/${official_tar}
+
+	cp --verbose \
+		${HOME}/my/data/for_programs/keepass/${database_kdbx} \
+		${HOME}/my/data/for_programs/keepass/${database_bak}
+	mv --verbose ./${database_kdbx} ./data/for_programs/keepass/
+
+	rm --verbose --recursive --force ${HOME}/my/official/
+	tar --directory=${HOME}/my xvf /tmp/${official_tar}
+
+	rm --verbose ${database_kdbx}
+	rm --verbose ${official_tar}
+
+	popd # /tmp
+}
+
+main "${@}"

--- a/user_account/scripts/backup_deploy.sh
+++ b/user_account/scripts/backup_deploy.sh
@@ -15,8 +15,8 @@ main() {
 
 	pushd /tmp
 
-	wget ${server_ip}:8000/${database_kdbx}
-	wget ${server_ip}:8000/${official_tar}
+	wget http://${server_ip}:8000/${database_kdbx}
+	wget http://${server_ip}:8000/${official_tar}
 
 	cp --verbose \
 		${HOME}/my/data/for_programs/keepass/${database_kdbx} \
@@ -26,7 +26,7 @@ main() {
 	rm --verbose --recursive --force ${HOME}/my/official/
 	tar --directory=${HOME}/my -x -v -f /tmp/${official_tar}
 
-	rm --verbose ${official_tar}
+	rm --verbose ./${official_tar}
 
 	popd # /tmp
 }

--- a/user_account/scripts/backup_deploy.sh
+++ b/user_account/scripts/backup_deploy.sh
@@ -21,12 +21,11 @@ main() {
 	cp --verbose \
 		${HOME}/my/data/for_programs/keepass/${database_kdbx} \
 		${HOME}/my/data/for_programs/keepass/${database_bak}
-	mv --verbose ./${database_kdbx} ./data/for_programs/keepass/
+	mv --verbose ./${database_kdbx} ${HOME}/my/data/for_programs/keepass/
 
 	rm --verbose --recursive --force ${HOME}/my/official/
-	tar --directory=${HOME}/my xvf /tmp/${official_tar}
+	tar --directory=${HOME}/my -x -v -f /tmp/${official_tar}
 
-	rm --verbose ${database_kdbx}
 	rm --verbose ${official_tar}
 
 	popd # /tmp

--- a/user_account/scripts/backup_serve.sh
+++ b/user_account/scripts/backup_serve.sh
@@ -5,12 +5,12 @@ set -e
 main() {
 	local -r official_tar='official.tar'
 	local -r database_kdbx='Database.kdbx'
-	local -r share_http_directory="${HOME}/share_http"
+	local -r share_http_directory="${HOME}/my/share_http"
 
 	pushd "${share_http_directory}"
 
-	tar --directory=${HOME}/my cvf ${share_http_directory}/${official_tar} ./official/
-	cp --verbose ./data/for_programs/keepass/${database_kdbx} ./
+	tar --directory=${HOME}/my -c -v -f ${share_http_directory}/${official_tar} ./official/
+	cp --verbose ${HOME}/my/data/for_programs/keepass/${database_kdbx} ./
 
 	ip addr
 	python3 -m http.server

--- a/user_account/scripts/backup_serve.sh
+++ b/user_account/scripts/backup_serve.sh
@@ -12,7 +12,7 @@ main() {
 	tar --directory=${HOME}/my -c -v -f ${share_http_directory}/${official_tar} ./official/
 	cp --verbose ${HOME}/my/data/for_programs/keepass/${database_kdbx} ./
 
-	ip addr
+	ip -4 -brief address show
 	python3 -m http.server
 	rm --verbose ${database_kdbx}
 	rm --verbose ${official_tar}

--- a/user_account/scripts/backup_serve.sh
+++ b/user_account/scripts/backup_serve.sh
@@ -5,19 +5,19 @@ set -e
 main() {
 	local -r official_tar='official.tar'
 	local -r database_kdbx='Database.kdbx'
-	local -r share_http_directory="${HOME}/my/share_http"
+	local -r directory_share_http="${HOME}/my/share_http"
 
-	pushd "${share_http_directory}"
+	pushd "${directory_share_http}"
 
-	tar --directory=${HOME}/my -c -v -f ${share_http_directory}/${official_tar} ./official/
+	tar --directory=${HOME}/my -c -v -f ${directory_share_http}/${official_tar} ./official/
 	cp --verbose ${HOME}/my/data/for_programs/keepass/${database_kdbx} ./
 
 	ip -4 -brief address show
 	python3 -m http.server
-	rm --verbose ${database_kdbx}
-	rm --verbose ${official_tar}
+	rm --verbose ./${database_kdbx}
+	rm --verbose ./${official_tar}
 
-	popd # "${share_http_directory}"
+	popd # "${directory_share_http}"
 }
 
 main "${@}"

--- a/user_account/scripts/backup_serve.sh
+++ b/user_account/scripts/backup_serve.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+main() {
+	local -r official_tar='official.tar'
+	local -r database_kdbx='Database.kdbx'
+	local -r share_http_directory="${HOME}/share_http"
+
+	pushd "${share_http_directory}"
+
+	tar --directory=${HOME}/my cvf ${share_http_directory}/${official_tar} ./official/
+	cp --verbose ./data/for_programs/keepass/${database_kdbx} ./
+
+	ip addr
+	python3 -m http.server
+	rm --verbose ${database_kdbx}
+	rm --verbose ${official_tar}
+
+	popd # "${share_http_directory}"
+}
+
+main "${@}"

--- a/user_account/scripts/print_ip.sh
+++ b/user_account/scripts/print_ip.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ip -4 -brief address show


### PR DESCRIPTION
Implementing #48 

The serve script is intended to be ran on the host whose files should be backed up. Another host is intended to download the served files. The deploy script can be used to download files that are being backed up and to proceed to write the downloaded files to the local directory hierarchy, deleting the previous official notes.