### PR TITLE
Read backup transfer port from password database

### DIFF
--- a/user_account/scripts/backup_deploy.sh
+++ b/user_account/scripts/backup_deploy.sh
@@ -13,10 +13,18 @@ main() {
 		exit 1
 	fi
 
+	local -r transfer_port=$(keepassxc-cli \
+		show --show-protected \
+		${HOME}/my/data/for_programs/keepass/Database.kdbx \
+		"for_automation/backups/transfer_port" \
+		| grep "Password:" \
+		| tr -d ' ' \
+		| cut -d ':' -f 2)
+
 	pushd /tmp
 
-	wget http://${server_ip}:8000/${database_kdbx}
-	wget http://${server_ip}:8000/${official_tar}
+	wget http://${server_ip}:${transfer_port}/${database_kdbx}
+	wget http://${server_ip}:${transfer_port}/${official_tar}
 
 	cp --verbose \
 		${HOME}/my/data/for_programs/keepass/${database_kdbx} \

--- a/user_account/scripts/backup_serve.sh
+++ b/user_account/scripts/backup_serve.sh
@@ -7,13 +7,21 @@ main() {
 	local -r database_kdbx='Database.kdbx'
 	local -r directory_share_http="${HOME}/my/share_http"
 
+	local -r transfer_port=$(keepassxc-cli \
+		show --show-protected \
+		${HOME}/my/data/for_programs/keepass/Database.kdbx \
+		"for_automation/backups/transfer_port" \
+		| grep "Password:" \
+		| tr -d ' ' \
+		| cut -d ':' -f 2)
+
 	pushd "${directory_share_http}"
 
 	tar --directory=${HOME}/my -c -v -f ${directory_share_http}/${official_tar} ./official/
 	cp --verbose ${HOME}/my/data/for_programs/keepass/${database_kdbx} ./
 
 	ip -4 -brief address show
-	python3 -m http.server
+	python3 -m http.server ${transfer_port}
 	rm --verbose ./${database_kdbx}
 	rm --verbose ./${official_tar}
 


### PR DESCRIPTION
Implementing #54 

The port use needs to be allowed in firewall configuration. Generation script of nftables configuration that allows the port can be found from 'config' repository.